### PR TITLE
Fix blank command handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,10 +63,13 @@ function updateLastLogin() {
 
 // split input into command, options, and arguments.
 function inputToCOA(input) {
-  let inputArray = input.match(/(".*?"|[^",\s]+)/g);
-  let command = inputArray[0];
+  if (!input.trim()) {
+    return { command: "", options: [], args: [] };
+  }
+  let inputArray = input.match(/(".*?"|[^",\s]+)/g) || [];
+  let command = inputArray[0] || "";
   let options = inputArray.slice(1, inputArray.length - 1);
-  let args = inputArray.slice(-1, inputArray.length);
+  let args = inputArray.slice(-1);
   return { command, options, args };
 }
 
@@ -145,6 +148,12 @@ function processCommand(input) {
 cmdInput.addEventListener("keypress", (event) => {
   if (event.key === "Enter") {
     let input = event.target.value.toString();
+    if (!input.trim()) {
+      inputArea.innerHTML += cmdHandler("", "");
+      event.target.value = "";
+      scrollToBottom();
+      return;
+    }
     let argv = inputToCOA(input);
 
     switch (argv.command.toLowerCase()) {

--- a/modules/terminalCommands.js
+++ b/modules/terminalCommands.js
@@ -13,7 +13,7 @@ let terminalCommands = {
     <span class="cmd">touch</span> - creates a new empty file
     <span class="cmd">mkdir</span> - creates a new directory
     <span class="cmd">rm</span> - removes a file or directory
-    <span class="cmd">`;
+    `;
   },
   listFiles: (fs) => {
     let output = "";


### PR DESCRIPTION
## Summary
- handle empty input gracefully in parser and keypress handler
- clean up help text formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a5587b908321921dcae99a508e28