### PR TITLE
Fix typo in filesystem initialization comment

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ const COMMANDS = [
   "rm",
 ];
 
-// instatiates the filesystem and sets the current directory and files.
+// instantiates the filesystem and sets the current directory and files.
 const lesson1 = mockFileSystem();
 const activeFileSystem = lesson1;
 


### PR DESCRIPTION
## Summary
- fix a typo in `app.js`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6841a667fff4832183f9d8e21aacbe02