### PR TITLE
Fix help output

### DIFF
--- a/modules/terminalCommands.js
+++ b/modules/terminalCommands.js
@@ -12,8 +12,7 @@ let terminalCommands = {
     <span class="cmd">echo</span> - displays lines of text or string passed as arguments
     <span class="cmd">touch</span> - creates a new empty file
     <span class="cmd">mkdir</span> - creates a new directory
-    <span class="cmd">rm</span> - removes a file or directory
-    <span class="cmd">`;
+    <span class="cmd">rm</span> - removes a file or directory`;
   },
   listFiles: (fs) => {
     let output = "";


### PR DESCRIPTION
## Summary
- close HTML tags in the `help` command string

## Testing
- `node -e "import('./modules/terminalCommands.js').then(m=>console.log('loaded'))"`

------
https://chatgpt.com/codex/tasks/task_e_6841a6d96d2083219d7f91f988c6358a