### PR TITLE
Add lesson help command and extend help page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Current Commands:
 
 Use the `lesson` command to start a guided exercise. When you finish a lesson by entering the correct command, the help bar will confirm completion and prompt you for the next lesson.
 
+Run `lesson --help` for details on how the lesson system works and how to start a specific lesson.
+
 Live Project: [Interactive Terminal](https://myquite.github.io/interactive-terminal/)
 
 ## Priority Tasks

--- a/app.js
+++ b/app.js
@@ -225,9 +225,14 @@ cmdInput.addEventListener("keypress", (event) => {
         );
         break;
       case "lesson":
-        inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
-        helpBar.innerHTML = lc.lesson(argv.args);
-        currentLesson = parseInt(argv.args[0]);
+        if (argv.args[0] === "--help" || argv.args[0] === "-h" || !argv.args[0]) {
+          inputArea.innerHTML += cmdHandler(lc.lesson(["--help"]), input);
+          helpBar.innerHTML = "";
+        } else {
+          inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
+          helpBar.innerHTML = lc.lesson(argv.args);
+          currentLesson = parseInt(argv.args[0]);
+        }
         break;
       case "test":
         inputArea.innerHTML += cmdHandler(

--- a/modules/lessonCommands.js
+++ b/modules/lessonCommands.js
@@ -1,12 +1,22 @@
 let lessonCommands = {
-  lesson: (arg) => {
-    let lessonNumber = arg.toString();
+  lesson: (args) => {
+    // Normalize arguments coming from argv.args
+    const firstArg = Array.isArray(args) ? args[0] : args;
+
+    // Display usage information when called with --help or no args
+    if (!firstArg || firstArg === "--help" || firstArg === "-h") {
+      return (
+        "Use the <span class=\"cmd\">lesson &lt;number&gt;</span> command to " +
+        "start a guided exercise. Example: <span class=\"cmd\">lesson 1</span>."
+      );
+    }
+
+    const lessonNumber = firstArg.toString();
     switch (lessonNumber) {
       case "1":
-        let output = `<span class="cmd">Lesson ${arg}:</span> Find out where you are in the file system with the <em>'pwd'</em> command.`;
-        return output;
+        return `<span class=\"cmd\">Lesson ${lessonNumber}:</span> Find out where you are in the file system with the <em>'pwd'</em> command.`;
       default:
-        console.log(`Sorry`);
+        return `Sorry, lesson ${lessonNumber} not found.`;
     }
   },
 };

--- a/modules/terminalCommands.js
+++ b/modules/terminalCommands.js
@@ -3,6 +3,7 @@
 let terminalCommands = {
   help: () => {
     return `
+    <strong>Commands</strong>
     <span class="cmd">help</span> - displays this help message
     <span class="cmd">clear</span> - clears the terminal
     <span class="cmd">ls</span> - lists files and folders in the current directory
@@ -12,7 +13,11 @@ let terminalCommands = {
     <span class="cmd">echo</span> - displays lines of text or string passed as arguments
     <span class="cmd">touch</span> - creates a new empty file
     <span class="cmd">mkdir</span> - creates a new directory
-    <span class="cmd">rm</span> - removes a file or directory`;
+    <span class="cmd">rm</span> - removes a file or directory
+
+    <br/><br/><strong>Lessons</strong>
+    <span class="cmd">lesson &lt;number&gt;</span> - start a guided lesson
+    <span class="cmd">lesson --help</span> - how lessons work`;
   },
   listFiles: (fs) => {
     let output = "";


### PR DESCRIPTION
## Summary
- support `lesson --help` in `lessonCommands`
- expand `help` output with dedicated Lesson section
- handle `lesson --help` command in `app.js`
- document lesson help in README

## Testing
- `node app.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad30bd008321803c90ebcf291315