### PR TITLE
Add lesson reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Use the `lesson` command to start a guided exercise. When you finish a lesson by
 
 Run `lesson --help` for details on how the lesson system works and how to start a specific lesson.
 
+Use `lesson reset` to restart the lesson progress at any time.
+
 Live Project: [Interactive Terminal](https://myquite.github.io/interactive-terminal/)
 
 ## Priority Tasks

--- a/app.js
+++ b/app.js
@@ -49,6 +49,12 @@ function updateProgressBar() {
   progressBar.style.width = `${percent}%`;
 }
 
+function resetLessons() {
+  completedLessons = 0;
+  currentLesson = null;
+  updateProgressBar();
+}
+
 // Sets the prompt for the terminal and includes the current working directory if not root.
 function setPrompt() {
   let currentDir = activeFileSystem.currentWorkingDirectory.split("/").pop();
@@ -242,6 +248,10 @@ cmdInput.addEventListener("keypress", (event) => {
         if (argv.args[0] === "--help" || argv.args[0] === "-h" || !argv.args[0]) {
           inputArea.innerHTML += cmdHandler(lc.lesson(["--help"]), input);
           helpBar.innerHTML = "";
+        } else if (argv.args[0] === "reset") {
+          inputArea.innerHTML += cmdHandler(lc.lesson(["reset"]), input);
+          helpBar.innerHTML = "";
+          resetLessons();
         } else {
           inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
           helpBar.innerHTML = lc.lesson(argv.args);

--- a/modules/lessonCommands.js
+++ b/modules/lessonCommands.js
@@ -11,6 +11,10 @@ let lessonCommands = {
       );
     }
 
+    if (firstArg === "reset") {
+      return "Lesson progress reset.";
+    }
+
     const lessonNumber = firstArg.toString();
     switch (lessonNumber) {
       case "1":


### PR DESCRIPTION
## Summary
- add `resetLessons` helper and hook into `lesson` command
- show `lesson reset` information in documentation
- implement `lesson reset` handling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841afca739083218d1a524f8c145ac9