### PR TITLE
Add `lesson ls` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Use the `lesson` command to start a guided exercise. When you finish a lesson by
 Run `lesson --help` for details on how the lesson system works and how to start a specific lesson.
 
 Use `lesson reset` to restart the lesson progress at any time.
+Use `lesson ls` to list all available lessons.
 
 Live Project: [Interactive Terminal](https://myquite.github.io/interactive-terminal/)
 

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 
 import mockFileSystem from "./modules/filesystem.js";
 import tc from "./modules/terminalCommands.js";
-import lc from "./modules/lessonCommands.js";
+import lc, { lessons } from "./modules/lessonCommands.js";
 import { test, expect } from "././modules/test.js";
 
 // Add command history tracking
@@ -35,9 +35,9 @@ const helpBar = document.querySelector("#helpBar");
 const progressBar = document.querySelector("#progressBar");
 
 // Keep track of which lesson is currently active
-const lessonObjectives = {
-  1: "pwd",
-};
+const lessonObjectives = Object.fromEntries(
+  Object.entries(lessons).map(([num, data]) => [parseInt(num), data.command])
+);
 let currentLesson = null;
 
 // Progress tracking
@@ -252,6 +252,9 @@ cmdInput.addEventListener("keypress", (event) => {
           inputArea.innerHTML += cmdHandler(lc.lesson(["reset"]), input);
           helpBar.innerHTML = "";
           resetLessons();
+        } else if (argv.args[0] === "ls") {
+          inputArea.innerHTML += cmdHandler(lc.lesson(["ls"]), input);
+          helpBar.innerHTML = "";
         } else {
           inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
           helpBar.innerHTML = lc.lesson(argv.args);

--- a/modules/lessonCommands.js
+++ b/modules/lessonCommands.js
@@ -1,3 +1,20 @@
+const lessons = {
+  1: {
+    description:
+      "Find out where you are in the file system with the <em>'pwd'</em> command.",
+    command: "pwd",
+  },
+};
+
+function listLessons() {
+  return Object.keys(lessons)
+    .map(
+      (num) =>
+        `<span class=\"cmd\">${num}</span> - ${lessons[num].description}`
+    )
+    .join("<br>");
+}
+
 let lessonCommands = {
   lesson: (args) => {
     // Normalize arguments coming from argv.args
@@ -7,7 +24,8 @@ let lessonCommands = {
     if (!firstArg || firstArg === "--help" || firstArg === "-h") {
       return (
         "Use the <span class=\"cmd\">lesson &lt;number&gt;</span> command to " +
-        "start a guided exercise. Example: <span class=\"cmd\">lesson 1</span>."
+        "start a guided exercise. Example: <span class=\"cmd\">lesson 1</span>." +
+        " Use <span class=\"cmd\">lesson ls</span> to list lessons."
       );
     }
 
@@ -15,14 +33,17 @@ let lessonCommands = {
       return "Lesson progress reset.";
     }
 
-    const lessonNumber = firstArg.toString();
-    switch (lessonNumber) {
-      case "1":
-        return `<span class=\"cmd\">Lesson ${lessonNumber}:</span> Find out where you are in the file system with the <em>'pwd'</em> command.`;
-      default:
-        return `Sorry, lesson ${lessonNumber} not found.`;
+    if (firstArg === "ls") {
+      return listLessons();
     }
+
+    const lessonNumber = firstArg.toString();
+    if (lessons[lessonNumber]) {
+      return `<span class=\"cmd\">Lesson ${lessonNumber}:</span> ${lessons[lessonNumber].description}`;
+    }
+    return `Sorry, lesson ${lessonNumber} not found.`;
   },
 };
 
+export { lessons };
 export default lessonCommands;


### PR DESCRIPTION
## Summary
- allow listing available lessons
- show `lesson ls` in README

## Testing
- `node -e "import('./modules/lessonCommands.js').then(m=>console.log('ok')).catch(e=>console.error(e));"`
- `node --check modules/lessonCommands.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6841b299e70c83219472c5c270e8f9b1