### PR TITLE
Fix layout so only main scrolls

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ const cmdInput = document.querySelector("#cmdInput");
 const inputArea = document.querySelector("#inputArea");
 const lastLogin = document.querySelector(".lastLogin");
 const terminal = document.querySelector("#terminal");
+const main = document.querySelector("main");
 const workingDir = document.querySelector(".workingDir");
 const helpBar = document.querySelector("#helpBar");
 const progressBar = document.querySelector("#progressBar");
@@ -68,7 +69,7 @@ function setPrompt() {
 
 // Scrolls the terminal view to the bottom
 function scrollToBottom() {
-  terminal.scrollTop = terminal.scrollHeight;
+  main.scrollTop = main.scrollHeight;
 }
 
 // builds and sets the last login info  when page is first loaded

--- a/style.css
+++ b/style.css
@@ -40,22 +40,19 @@ body {
   width: 100vw;
   height: 85%;
   background-color: rgba(27, 43, 52, 0.9);
-  overflow-y: scroll;
+  overflow: hidden;
   z-index: 0;
-  -webkit-overflow-scrolling: touch; /* Smooth scrolling on mobile */
-  scrollbar-width: thin; /* Firefox */
-  scrollbar-color: #76e8fe rgba(27, 43, 52, 0.5); /* Firefox */
 }
 
-#terminal::-webkit-scrollbar {
+main::-webkit-scrollbar {
   width: 8px;
 }
 
-#terminal::-webkit-scrollbar-track {
+main::-webkit-scrollbar-track {
   background: rgba(27, 43, 52, 0.5);
 }
 
-#terminal::-webkit-scrollbar-thumb {
+main::-webkit-scrollbar-thumb {
   background-color: #76e8fe;
   border-radius: 4px;
 }
@@ -93,8 +90,13 @@ header {
 
 main {
   flex: auto;
+  min-height: 0;
   padding: 0.5rem 1rem;
   color: #fffeff;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch; /* Smooth scrolling on mobile */
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: #76e8fe rgba(27, 43, 52, 0.5); /* Firefox */
 }
 
 footer {
@@ -233,7 +235,7 @@ p {
     max-height: 600px;
     border-radius: 10px 10px 0 0;
     background-color: rgba(27, 43, 52, 0.9);
-    overflow-y: scroll;
+    overflow: hidden;
   }
 
   header {


### PR DESCRIPTION
## Summary
- restrict scrolling to the `<main>` element
- style scrollbar on `<main>`
- update JavaScript to scroll `<main>` instead of the entire terminal

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841b745e910832188f00a2b97c83bc2