### PR TITLE
Fix invalid lesson handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,9 +257,16 @@ cmdInput.addEventListener("keypress", (event) => {
           inputArea.innerHTML += cmdHandler(lc.lesson(["ls"]), input);
           helpBar.innerHTML = "";
         } else {
-          inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
-          helpBar.innerHTML = lc.lesson(argv.args);
-          currentLesson = parseInt(argv.args[0]);
+          const lessonNum = argv.args[0];
+          const lessonMsg = lc.lesson(argv.args);
+          helpBar.innerHTML = lessonMsg;
+          if (lessons[lessonNum]) {
+            inputArea.innerHTML += cmdHandler("Lesson Loaded", input);
+            currentLesson = parseInt(lessonNum);
+          } else {
+            inputArea.innerHTML += cmdHandler(lessonMsg, input);
+            currentLesson = null;
+          }
         }
         break;
       case "test":


### PR DESCRIPTION
## Summary
- handle invalid lesson numbers in the lesson command

## Testing
- `node - <<'NODE'
import lc, { lessons } from './modules/lessonCommands.js';
function simulate(input) {
  const argv = { args: [input] };
  const lessonNum = argv.args[0];
  const lessonMsg = lc.lesson(argv.args);
  let message;
  let currentLesson;
  if (lessons[lessonNum]) {
    message = 'Lesson Loaded';
    currentLesson = parseInt(lessonNum);
  } else {
    message = lessonMsg;
    currentLesson = null;
  }
  console.log('message', message);
  console.log('helpBar', lessonMsg);
  console.log('currentLesson', currentLesson);
}
simulate('1');
simulate('2');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6841bb00b0248321bcba54f31e21fc16