### PR TITLE
Improve mock filesystem

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,7 +143,8 @@ function handleTabCompletion() {
   }
   // File/directory completion
   else {
-    const currentFiles = activeFileSystem.currentFileSystem;
+    const currentFiles =
+      activeFileSystem.structure[activeFileSystem.currentWorkingDirectory] || [];
     const matches = currentFiles
       .filter((file) => file.name.startsWith(lastWord))
       .map((file) => file.name);
@@ -213,7 +214,7 @@ cmdInput.addEventListener("keypress", (event) => {
         break;
       case "ls":
         inputArea.innerHTML += cmdHandler(
-          tc.listFiles(activeFileSystem.currentFileSystem),
+          tc.listFiles(activeFileSystem),
           input
         );
         break;
@@ -222,7 +223,7 @@ cmdInput.addEventListener("keypress", (event) => {
         break;
       case "cat":
         inputArea.innerHTML += cmdHandler(
-          tc.cat(activeFileSystem.currentFileSystem, argv.args),
+          tc.cat(activeFileSystem, argv.args),
           input
         );
         break;

--- a/modules/filesystem.js
+++ b/modules/filesystem.js
@@ -1,13 +1,30 @@
 function mockFileSystem() {
+  const root = "/Users/myquite";
+  const base = `${root}/Sites/js-terminal`;
+
+  // simple map of absolute paths to their contents
+  const structure = {};
+
+  // root level
+  structure[root] = [{ name: "Sites", type: "directory" }];
+  structure[`${root}/Sites`] = [{ name: "js-terminal", type: "directory" }];
+
+  structure[base] = [
+    { name: "styles", type: "directory" },
+    { name: "scripts", type: "directory" },
+    { name: "images", type: "directory" },
+    { name: "index.html", type: "file", contents: "Hello World" },
+  ];
+
+  // initialize empty directories
+  structure[`${base}/styles`] = [];
+  structure[`${base}/scripts`] = [];
+  structure[`${base}/images`] = [];
+
   return {
-    root: "/Users/myquite",
-    currentWorkingDirectory: "/Users/myquite/Sites/js-terminal",
-    currentFileSystem: [
-      { name: "styles", type: "directory" },
-      { name: "scripts", type: "directory" },
-      { name: "images", type: "directory" },
-      { name: "index.html", type: "file", contents: "Hello World" },
-    ],
+    root,
+    currentWorkingDirectory: base,
+    structure,
   };
 }
 


### PR DESCRIPTION
## Summary
- redesign mock filesystem to track directories by absolute path
- support nested directories in terminal commands
- use new structure in application logic

## Testing
- `node -e "import fs from './modules/filesystem.js'; import tc from './modules/terminalCommands.js'; const f=fs(); console.log(tc.pwd(f)); console.log(tc.listFiles(f));"`
- `node - <<'EOF'
import fs from './modules/filesystem.js';
import tc from './modules/terminalCommands.js';
const f=fs();
console.log('pwd1', tc.pwd(f));
console.log('ls1', tc.listFiles(f));
console.log('mkdir', tc.mkdir(f,['testdir']));
console.log('ls2', tc.listFiles(f));
console.log('cd', tc.cd(f,'testdir'));
console.log('pwd2', tc.pwd(f));
console.log('touch', tc.touch(f,['foo.txt']));
console.log('ls3', tc.listFiles(f));
console.log('cd back', tc.cd(f,'..'));
console.log('pwd3', tc.pwd(f));
EOF

------
https://chatgpt.com/codex/tasks/task_e_6841e0f1133483218664d72723d73321